### PR TITLE
Develop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,4 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+quote_type = single

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,3 +21,16 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: cazocar/node-microservice-boilerplate
+
+  deploy_to_heroku:
+    name: Deploy to Heroku
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+      - name: Login to Heroku Container Registry
+        uses: docker login --username=_ --password=${{ secrets.HEROKU_API_KEY }} registry.heroku.com
+      - name: Build image
+        uses: docker build -t registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web .
+      - name: Push image
+        uses: docker push registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM base AS development
 ENV NODE_ENV=development
 RUN npm install
 COPY . .
-CMD ["npm", "run", "dev"]
+CMD ["nodemon", "src/server.ts"]
 
 FROM development AS builder
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ On the other hand, the `cd.yml` pipeline is responsible for the `Continuous Deli
 - Build a Docker image
 - Push the image to Docker Hub
 
+**Important:** Remember to change the Docker Hub repository name and store your credentials in the `Secrets` section of your GitHub repository configuration (`Settings > Secrets`).
+
 This actions are triggered whenever a `push` is made to the `master` branch and it affects files found in the `src` folder or in the `package.json` file, so it only executes when stable changes are ready to be deployed.
 
 ## Deployment

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node dist/src/server.js",
     "dev": "nodemon src/server.ts",
     "build": "tsc",
     "postbuild": "copyfiles -u 1 settings/default.yml dist/settings",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint \"**/*.{js,ts}\"",
-    "lint:fix": "eslint --fix \"**/*.{js,ts}\""
+    "lint:fix": "eslint --fix \"**/*.{js,ts}\"",
+    "docker:build": "docker build -t microservice-boilerplate .",
+    "docker:run": "docker run -d -p 3000:3000 --name microservice-boilerplate microservice-boilerplate"
   },
   "keywords": [],
   "author": "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist",
+    "outDir": "dist/src",
     "paths": {
       "*": ["*"]
     }


### PR DESCRIPTION
- Add a job in the CD pipeline to deploy to Heroku
- Use direct commands in Dockerfile instead of running npm scripts
- Add scripts to package.json
- Change output directory of compiled TypeScript files
- Add anotation in README